### PR TITLE
Fixed error when the currently logged on user is in a list

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User
 
   def follow_list(user, list)
     users_to_follow = @client.list_members(user, list, skip_status: true, include_entities: false).to_a
+    client_id = @client.user.id
+    users_to_follow.delete_if { |x| x.id == client_id }
     @client.follow(users_to_follow)
   end
 end

--- a/test/functional/follows_controller_test.rb
+++ b/test/functional/follows_controller_test.rb
@@ -21,6 +21,8 @@ class FollowsControllerTest < ActionController::TestCase
       to_return(body: File.read(File.expand_path('../../fixtures/users.json', __FILE__)))
     stub_request(:post, 'https://api.twitter.com/1.1/friendships/create.json').
       to_return(body: File.read(File.expand_path('../../fixtures/user.json', __FILE__)))
+    stub_request(:get, 'https://api.twitter.com/1.1/account/verify_credentials.json').
+      to_return(body: File.read(File.expand_path('../../fixtures/user.json', __FILE__)))
     post :create, list: 'codeforamerica/team'
     assert_not_nil assigns :user
     assert_not_nil assigns :new_friends


### PR DESCRIPTION
When a user tried to a follow a list of people and the user is in that list, it would error out. There is an error checking process on the array of twitter IDs. The client ID is gathered and stored as a variable and then a loop is ran against the array of new people. If the IDs are a match, then it's removed from the array.

This is requested from #22 

Signed-off-by: Kendrick Coleman kendrickcoleman@gmail.com
